### PR TITLE
Add missing dependency to "file"

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -87,9 +87,9 @@
             runtimeInputs = [
               pkgs.espflash
               pkgs.esptool
+              pkgs.file
               pkgs.gnugrep
               pkgs.netcat
-              pkgs.file
               qemu-esp32c3
             ];
             text = ''
@@ -162,6 +162,7 @@
             packages = [
               pkgs.espflash
               pkgs.esptool
+              pkgs.file
               pkgs.gnugrep
               pkgs.netcat
               qemu-esp32c3

--- a/flake.nix
+++ b/flake.nix
@@ -89,6 +89,7 @@
               pkgs.esptool
               pkgs.gnugrep
               pkgs.netcat
+              pkgs.file
               qemu-esp32c3
             ];
             text = ''


### PR DESCRIPTION
The scripts depend on the `file` command, yet it is not installed as a dependency.